### PR TITLE
Force Pixel Format

### DIFF
--- a/render.go
+++ b/render.go
@@ -61,18 +61,13 @@ func render(commands <-chan Command, inputs chan<- byte) {
 	defer renderer.Destroy()
 	_ = renderer.SetDrawBlendMode(sdl.BLENDMODE_BLEND)
 
-	format, err := window.GetPixelFormat()
-	if err != nil {
-		panic(err)
-	}
-
-	background, err := renderer.CreateTexture(format, sdl.TEXTUREACCESS_TARGET, windowWidth, windowHeight)
+	background, err := renderer.CreateTexture(sdl.PIXELFORMAT_ARGB8888, sdl.TEXTUREACCESS_TARGET, windowWidth, windowHeight)
 	if err != nil {
 		panic(err)
 	}
 	defer background.Destroy()
 
-	overlay, err := renderer.CreateTexture(format, sdl.TEXTUREACCESS_TARGET, windowWidth, windowHeight)
+	overlay, err := renderer.CreateTexture(sdl.PIXELFORMAT_ABGR8888, sdl.TEXTUREACCESS_TARGET, windowWidth, windowHeight)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes an issue with my install (possibly other linux users too?)
Installed libSDL-1.2 from the setup instructions listed on https://github.com/veandco/go-sdl2#requirements

Pixel format from `window.getPixelFormat` returned `PIXELFORMAT_RGB888`
screen looked like this:

![](https://cdn.discordapp.com/attachments/754193301292449844/800840024610177034/unknown.png)

(note the lack of cursor)

Forcing the pixel format:
![](https://cdn.discordapp.com/attachments/754193301292449844/800879066571210752/unknown.png)
